### PR TITLE
[課題1.2] 取引可能な製造会社の一覧を表示する

### DIFF
--- a/packages/client/src/api/shop/index.ts
+++ b/packages/client/src/api/shop/index.ts
@@ -63,3 +63,34 @@ export const fetchShop = async (req: FetchShopRequest) => {
   const json = (await res.json()) as SuccessResponse<FetchShopResponse>;
   return json.data;
 };
+
+type FetchPartnerManufacturersRequest = {
+  shopId: string;
+  token: string;
+};
+
+type FetchPartnerManufacturersResponse = {
+  id: string;
+  name: string;
+  description: string;
+}[];
+
+export const fetchPartnerManufacturers = async (
+  req: FetchPartnerManufacturersRequest,
+): Promise<FetchPartnerManufacturersResponse> => {
+  const { shopId, token } = req;
+
+  const res = await fetch(`${APP_API_URL}/shops/${shopId}/partner-manufacturers`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error();
+  }
+  const json = (await res.json()) as SuccessResponse<FetchPartnerManufacturersResponse>;
+  return json.data;
+};

--- a/packages/client/src/components/domain/shop/HomePage.tsx
+++ b/packages/client/src/components/domain/shop/HomePage.tsx
@@ -1,3 +1,4 @@
+import { LinkCard } from '@/components/base/LinkCard';
 import styles from './HomePage.module.css';
 import { useAuthLoaderData } from '@/hooks/useAuthLoaderData';
 import { useEffect, useState } from 'react';
@@ -45,10 +46,12 @@ export const ShopHomePage = () => {
           </div>
         )}
         <div className={styles.linkList}>
-          {
-            // to-do
-            // main app
-          }
+          <LinkCard
+            title='製造会社一覧'
+            description='取引可能な製造会社を表示します'
+            href='/shop/manufacturers'
+            className={styles.linkCard}
+          />
         </div>
       </div>
     </>

--- a/packages/client/src/components/domain/shop/Layout.tsx
+++ b/packages/client/src/components/domain/shop/Layout.tsx
@@ -1,14 +1,28 @@
 import { Container } from '@/components/case/Container';
 import { HomeHeader } from '@/components/common/HomeHeader';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import styles from './Layout.module.css';
+import { Breadcrumb } from '@/components/case/Breadcrumb';
 
 export const ShopLayout = () => {
+  const location = useLocation();
+  const isLoginPage = location.pathname.includes('login');
+  const isManufacturerListPage = location.pathname.includes('shop/manufacturers');
+
+  let breadcrumbItems = [{ href: '/shop', title: '販売会社トップ' }];
+  if (isLoginPage) {
+    breadcrumbItems = [];
+  }
+  if (isManufacturerListPage) {
+    breadcrumbItems = [...breadcrumbItems, { href: '/shop/manufacturers', title: '製造会社一覧' }];
+  }
+
   return (
     <>
       <HomeHeader />
       <Container>
         <div className={styles.container}>
+          <Breadcrumb items={breadcrumbItems} />
           <Outlet />
         </div>
       </Container>

--- a/packages/client/src/components/domain/shop/ManufacturerListPage.tsx
+++ b/packages/client/src/components/domain/shop/ManufacturerListPage.tsx
@@ -1,0 +1,43 @@
+import { Column, Table } from '@/components/case/Table';
+import { useEffect, useState } from 'react';
+import * as shopApi from '@/api/shop';
+import { useAuthLoaderData } from '@/hooks/useAuthLoaderData';
+
+type Response = Awaited<ReturnType<typeof shopApi.fetchPartnerManufacturers>>;
+
+const usePartnerManufacturers = () => {
+  const loaderData = useAuthLoaderData();
+  const shopId = loaderData.id;
+  const token = loaderData.token;
+
+  const [manufacturers, setManufacturers] = useState<Response>([]);
+
+  useEffect(() => {
+    void shopApi.fetchPartnerManufacturers({ shopId, token }).then((manufacturers) => {
+      setManufacturers(manufacturers);
+    });
+  }, [shopId, token]);
+
+  return { manufacturers };
+};
+
+export const ManufacturerListPage = () => {
+  const { manufacturers } = usePartnerManufacturers();
+
+  const columns: Column<Response[number]>[] = [
+    {
+      header: 'ID',
+      accessor: (item) => item.id,
+    },
+    {
+      header: '会社名',
+      accessor: (item) => item.name,
+    },
+    {
+      header: '会社説明',
+      accessor: (item) => item.description,
+    },
+  ];
+
+  return <Table columns={columns} data={manufacturers} />;
+};

--- a/packages/client/src/pages/shop/manufacturers.tsx
+++ b/packages/client/src/pages/shop/manufacturers.tsx
@@ -1,0 +1,2 @@
+import { ManufacturerListPage } from '@/components/domain/shop/ManufacturerListPage';
+export default ManufacturerListPage;

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -7,9 +7,10 @@ import ManufacturerHomePage from './pages/manufacturer';
 import ManufacturerLayout from './pages/manufacturer/layout';
 import ManufacturerOrderListPage from './pages/manufacturer/orders';
 import ManufacturerOrderPage from './pages/manufacturer/order';
+import ShopHomePage from './pages/shop';
 import ShopLayout from './pages/shop/layout';
 import ShopLoginPage from './pages/shop/login';
-import ShopHomePage from './pages/shop';
+import ShopManufacturerListPage from './pages/shop/manufacturers';
 
 const router = createBrowserRouter([
   {
@@ -31,6 +32,7 @@ const router = createBrowserRouter([
     children: [
       { path: '/shop', element: <ShopHomePage />, loader: shopAuthLoader },
       { path: '/shop/login', element: <ShopLoginPage /> },
+      { path: '/shop/manufacturers', element: <ShopManufacturerListPage />, loader: shopAuthLoader },
     ],
   },
 ]);


### PR DESCRIPTION
## 概要
製造会社一覧画面、およびパンくずリストを実装

## やったこと
- UI実装・修正
  - [x] 製造会社一覧画面のUI実装
  - [x] トップ画面のUI修正
  - [x] ぱんくずリストの実装
- [x] 製造会社一覧取得用APIの実装 
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] その他満たすべき要件の満足（以降の課題にて対応）

## 動作確認
- [x] 販売会社としてログインし、製造会社一覧画面でデータが取得できることを確認
- [x] パンくずリストの表示と遷移先が正しいことを、トップ画面と製造会社一覧画面で確認
- [x] トップ画面のボタンの遷移先が製造会社一覧画面であることを確認

## 伝えるべきこと
### 実装意図
- 課題1.1同様、製造会社向けに実装されていた類似の機能や設計を参考に実装した

### レビューしてほしい点
- [ ] 正常に動作するかどうか
- [ ] コードの記法が適切かどうか
- [ ] テストや実装のもれがないか

### 共有事項


## UI
### トップ画面
before-after
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/5a69acf4-6fd8-42f9-8629-c95ceb2a12a4)
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/edc53ca6-c713-43c9-b619-5cdad9ea291a)
### 製造会社一覧画面
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/579128aa-462e-49fb-a033-f0e07b82f77b)


## その他
### 参考

