### PR TITLE
[課題1.3] 製造会社を選択し、取扱している商品一覧と在庫情報を表示する

### DIFF
--- a/packages/client/src/api/shop/index.ts
+++ b/packages/client/src/api/shop/index.ts
@@ -94,3 +94,39 @@ export const fetchPartnerManufacturers = async (
   const json = (await res.json()) as SuccessResponse<FetchPartnerManufacturersResponse>;
   return json.data;
 };
+
+type FetchHandlingProductsRequest = {
+  shopId: string;
+  manufacturerId: string;
+  token: string;
+};
+
+type FetchHandlingProductsResponse = {
+  products: {
+    id: string;
+    name: string;
+    description: string;
+    categories: { id: string; name: string }[];
+    stock: number;
+  }[];
+};
+
+export const fetchHandlingProducts = async (
+  req: FetchHandlingProductsRequest,
+): Promise<FetchHandlingProductsResponse> => {
+  const { shopId, manufacturerId, token } = req;
+
+  const res = await fetch(`${APP_API_URL}/shops/${shopId}/partner-manufacturers/${manufacturerId}/products`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error();
+  }
+  const json = (await res.json()) as SuccessResponse<FetchHandlingProductsResponse>;
+  return json.data;
+};

--- a/packages/client/src/components/domain/shop/Layout.tsx
+++ b/packages/client/src/components/domain/shop/Layout.tsx
@@ -6,8 +6,10 @@ import { Breadcrumb } from '@/components/case/Breadcrumb';
 
 export const ShopLayout = () => {
   const location = useLocation();
-  const isLoginPage = location.pathname.includes('login');
-  const isManufacturerListPage = location.pathname.includes('shop/manufacturers');
+  const isLoginPage = location.pathname == '/shop/login';
+  const isManufacturerListPage = location.pathname == '/shop/manufacturers';
+  const isManufacturerProductListPage =
+    location.pathname.includes('/shop/manufacturers') && location.pathname.includes('products');
 
   let breadcrumbItems = [{ href: '/shop', title: '販売会社トップ' }];
   if (isLoginPage) {
@@ -15,6 +17,13 @@ export const ShopLayout = () => {
   }
   if (isManufacturerListPage) {
     breadcrumbItems = [...breadcrumbItems, { href: '/shop/manufacturers', title: '製造会社一覧' }];
+  }
+  if (isManufacturerProductListPage) {
+    breadcrumbItems = [
+      ...breadcrumbItems,
+      { href: '/shop/manufacturers', title: '製造会社一覧' },
+      { href: location.pathname, title: '取扱商品一覧' },
+    ];
   }
 
   return (

--- a/packages/client/src/components/domain/shop/ManufacturerListPage.tsx
+++ b/packages/client/src/components/domain/shop/ManufacturerListPage.tsx
@@ -2,6 +2,7 @@ import { Column, Table } from '@/components/case/Table';
 import { useEffect, useState } from 'react';
 import * as shopApi from '@/api/shop';
 import { useAuthLoaderData } from '@/hooks/useAuthLoaderData';
+import { useNavigate } from 'react-router-dom';
 
 type Response = Awaited<ReturnType<typeof shopApi.fetchPartnerManufacturers>>;
 
@@ -22,6 +23,7 @@ const usePartnerManufacturers = () => {
 };
 
 export const ManufacturerListPage = () => {
+  const navigate = useNavigate();
   const { manufacturers } = usePartnerManufacturers();
 
   const columns: Column<Response[number]>[] = [
@@ -39,5 +41,13 @@ export const ManufacturerListPage = () => {
     },
   ];
 
-  return <Table columns={columns} data={manufacturers} />;
+  return (
+    <Table
+      columns={columns}
+      data={manufacturers}
+      onClick={(item) => {
+        navigate(`/shop/manufacturers/${item.id}/products`);
+      }}
+    />
+  );
 };

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.tsx
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.tsx
@@ -1,0 +1,92 @@
+import { Column, Table } from '@/components/case/Table';
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import * as shopApi from '@/api/shop';
+import { useAuthLoaderData } from '@/hooks/useAuthLoaderData';
+import { toast } from 'react-hot-toast';
+
+type FetchHandlingProductsResponse = Awaited<ReturnType<typeof shopApi.fetchHandlingProducts>>;
+
+const useHandleProducts = (manufacturerId: string) => {
+  const loaderData = useAuthLoaderData();
+  const shopId = loaderData.id;
+  const token = loaderData.token;
+
+  const [products, setProducts] = useState<FetchHandlingProductsResponse | null>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    setIsLoading(true);
+    shopApi
+      .fetchHandlingProducts({ shopId, manufacturerId, token })
+      .then((products) => {
+        setProducts(products);
+        setError(null);
+      })
+      .catch((error: Error) => {
+        setError(error);
+        setProducts(null);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, [shopId, manufacturerId, token]);
+
+  return { products, isLoading, error };
+};
+
+export const ManufacturerProductListPage = () => {
+  const navigate = useNavigate();
+  const params = useParams();
+  const manufacturerId = params['manufacturerId'] ?? '';
+  const { products, isLoading, error } = useHandleProducts(manufacturerId);
+  const items = isLoading ? [] : products?.products ?? [];
+
+  const columns: Column<(typeof items)[number]>[] = [
+    {
+      header: 'ID',
+      accessor: (item) => item.id,
+    },
+    {
+      header: '商品名',
+      accessor: (item) => item.name,
+    },
+    {
+      header: '商品説明',
+      accessor: (item) => item.description,
+    },
+    {
+      header: '商品カテゴリ',
+      accessor: (item) => item.categories.map((category) => category.name).join('・'),
+    },
+    {
+      header: '在庫',
+      accessor: (item) => item.stock,
+    },
+  ];
+
+  useEffect(() => {
+    if (error) {
+      toast.error('データの取得に失敗しました');
+      const timer = setTimeout(() => {
+        navigate('/shop/manufacturers');
+      }, 2000);
+      return () => {
+        clearTimeout(timer);
+      };
+    }
+  }, [error, navigate]);
+
+  if (items.length === 0 && !isLoading) {
+    return <p>商品がありません</p>;
+  }
+
+  return isLoading ? (
+    <>
+      <p>読み込み中...</p>
+    </>
+  ) : (
+    <Table columns={columns} data={items} />
+  );
+};

--- a/packages/client/src/pages/shop/manufacturer-products.tsx
+++ b/packages/client/src/pages/shop/manufacturer-products.tsx
@@ -1,0 +1,2 @@
+import { ManufacturerProductListPage } from '@/components/domain/shop/ManufacturerProductListPage';
+export default ManufacturerProductListPage;

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -11,6 +11,7 @@ import ShopHomePage from './pages/shop';
 import ShopLayout from './pages/shop/layout';
 import ShopLoginPage from './pages/shop/login';
 import ShopManufacturerListPage from './pages/shop/manufacturers';
+import ShopManufacturerProductListPage from './pages/shop/manufacturer-products';
 
 const router = createBrowserRouter([
   {
@@ -33,6 +34,11 @@ const router = createBrowserRouter([
       { path: '/shop', element: <ShopHomePage />, loader: shopAuthLoader },
       { path: '/shop/login', element: <ShopLoginPage /> },
       { path: '/shop/manufacturers', element: <ShopManufacturerListPage />, loader: shopAuthLoader },
+      {
+        path: '/shop/manufacturers/:manufacturerId/products',
+        element: <ShopManufacturerProductListPage />,
+        loader: shopAuthLoader,
+      },
     ],
   },
 ]);


### PR DESCRIPTION
## 概要
選択した製造会社の取扱商品一覧画面を実装

## やったこと
- [x] 取扱商品一覧画面のUI実装，APIつなぎこみ
- [x] 取扱商品一覧画面のAPI実装 
- [x] パンくずリストの追加，修正 
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] Hooksの別ファイルへの切り出し，抽象化
  - 以後のPRにてリファクタリングとして実施

## 動作確認
- [x] 正常：商品が存在する場合に，その一覧を表示する
- [x] 正常：商品が存在しない場合に，その旨を表示する 
- [x] 異常：エラーが返ってきた，もしくは`[manufacturerId]`が不正な場合に，エラーを表示し自動で前の画面に遷移する

## 伝えるべきこと
### 実装意図
- 各ファイルにおいては，製造会社向けのファイル群と似た記法での実装を心掛けた
- 一方，`@/components/domain/manufacturer/ProductListPage.tsx` では型のエラーが発生したことや，エラーハンドリングが必要である可能性を踏まえ，そのような処理を追加で記述した．

### レビューしてほしい点
- [ ] Hooksやエラーハンドリングのロジック・記法が適切かどうか

### 共有事項
- パンくずリストの第3項目に製造会社名を表示する場合，別の処理が必要．例えば[pathpidaライブラリ](https://zenn.dev/nozomi_iida/articles/20230508_pathpida)の導入が必要？

## UI
https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/e014b6b1-99dd-4c3d-b402-9df282eab7c0

## その他
### 参考

