### PR TITLE
[課題1.4] 商品一覧から発注する商品と個数を選択する

### DIFF
--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css
@@ -1,0 +1,8 @@
+.orderCell {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.orderInput {
+  width: 60px;
+}

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts
@@ -1,0 +1,6 @@
+declare const styles:
+  & Readonly<{ "orderCell": string }>
+  & Readonly<{ "orderInput": string }>
+;
+export default styles;
+//# sourceMappingURL=./ManufacturerProductListPage.module.css.d.ts.map

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts.map
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["./ManufacturerProductListPage.module.css"],"names":["orderCell","orderInput"],"mappings":"AAAA;AAAA,E,aAAAA,W,WAAA;AAAA,E,aAKAC,Y,WALA;AAAA;AAAA","file":"ManufacturerProductListPage.module.css.d.ts","sourceRoot":""}

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.tsx
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.tsx
@@ -1,4 +1,6 @@
 import { Column, Table } from '@/components/case/Table';
+import { TextInput } from '@/components/base/TextInput';
+import styles from './ManufacturerProductListPage.module.css';
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import * as shopApi from '@/api/shop';
@@ -64,6 +66,21 @@ export const ManufacturerProductListPage = () => {
       header: '在庫',
       accessor: (item) => item.stock,
     },
+    {
+      header: '発注',
+      accessor: (item) => (
+        <div className={styles.orderCell}>
+          <TextInput
+            type='number'
+            min={0}
+            name={`order_${item.id}`}
+            className={styles.orderInput}
+            defaultValue={0}
+            required
+          />
+        </div>
+      ),
+    },
   ];
 
   useEffect(() => {
@@ -87,6 +104,8 @@ export const ManufacturerProductListPage = () => {
       <p>読み込み中...</p>
     </>
   ) : (
-    <Table columns={columns} data={items} />
+    <form>
+      <Table columns={columns} data={items} />
+    </form>
   );
 };


### PR DESCRIPTION
## 概要
取扱商品一覧画面において，発注用に個数を入力できる列を各行に追加

## やったこと
- [x] 取扱商品一覧画面のUI追加実装
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] その他（実際の発注，APIの繋ぎこみ）．以後の開発にて実装

## 動作確認
- [x] 各列に当該の行が追加されている
- [x] 意図したスタイリングやpropsが適用されている

## 伝えるべきこと
### 実装意図
- 今までと同じく，製造会社向けページ（今回は`@/components/domain/manufacturer/ProductListPage.tsx`）を参考に実装

### レビューしてほしい点
- [ ] 実装範囲が適切かどうか
- [ ] スタイリングやロジックが適切かどうか

### 共有事項


## UI
### before/after
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/d470c89c-2b1e-40a2-8e20-9b5a6ff5e837)
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/9002cfb7-2525-4716-b010-db6000938884)


## その他
### 参考

