### PR TITLE
[課題1.5] 発注する商品と個数の一覧を確認する

### DIFF
--- a/packages/client/src/components/base/Modal.module.css
+++ b/packages/client/src/components/base/Modal.module.css
@@ -1,0 +1,24 @@
+.modal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  z-index: var(--z-index-popup);
+  width: 100%;
+  max-width: 1200px;
+  max-height: 80%;
+  padding: var(--spacing-lg);
+  overflow: auto;
+  background-color: var(--modal);
+  transform: translate(-50%, -50%);
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-index-overlay);
+  background-color: var(--overlay);
+}
+
+.modalButton {
+  margin: 12px 0;
+}

--- a/packages/client/src/components/base/Modal.module.css.d.ts
+++ b/packages/client/src/components/base/Modal.module.css.d.ts
@@ -1,0 +1,7 @@
+declare const styles:
+  & Readonly<{ "modal": string }>
+  & Readonly<{ "overlay": string }>
+  & Readonly<{ "modalButton": string }>
+;
+export default styles;
+//# sourceMappingURL=./Modal.module.css.d.ts.map

--- a/packages/client/src/components/base/Modal.module.css.d.ts.map
+++ b/packages/client/src/components/base/Modal.module.css.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["./Modal.module.css"],"names":["modal","overlay","modalButton"],"mappings":"AAAA;AAAA,E,aAAAA,O,WAAA;AAAA,E,aAcAC,S,WAdA;AAAA,E,aAqBAC,a,WArBA;AAAA;AAAA","file":"Modal.module.css.d.ts","sourceRoot":""}

--- a/packages/client/src/components/base/Modal.tsx
+++ b/packages/client/src/components/base/Modal.tsx
@@ -1,0 +1,27 @@
+import styles from './Modal.module.css';
+import { ReactNode } from 'react';
+import { Button } from '@/components/base/Button';
+
+type ModalProps = {
+  children: ReactNode;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const Modal: React.FC<ModalProps> = ({ children, isOpen, onClose }: ModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <>
+      <div className={styles.overlay} onClick={onClose} />
+      <div className={styles.modal}>
+        {children}
+        <div className={styles.modalButton}>
+          <Button variant='outlined' onClick={onClose}>
+            閉じる
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css
@@ -6,3 +6,9 @@
 .orderInput {
   width: 60px;
 }
+
+.modalButton {
+  display: flex;
+  justify-content: flex-end;
+  margin: 12px 0;
+}

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts
@@ -1,6 +1,7 @@
 declare const styles:
   & Readonly<{ "orderCell": string }>
   & Readonly<{ "orderInput": string }>
+  & Readonly<{ "modalButton": string }>
 ;
 export default styles;
 //# sourceMappingURL=./ManufacturerProductListPage.module.css.d.ts.map

--- a/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts.map
+++ b/packages/client/src/components/domain/shop/ManufacturerProductListPage.module.css.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./ManufacturerProductListPage.module.css"],"names":["orderCell","orderInput"],"mappings":"AAAA;AAAA,E,aAAAA,W,WAAA;AAAA,E,aAKAC,Y,WALA;AAAA;AAAA","file":"ManufacturerProductListPage.module.css.d.ts","sourceRoot":""}
+{"version":3,"sources":["./ManufacturerProductListPage.module.css"],"names":["orderCell","orderInput","modalButton"],"mappings":"AAAA;AAAA,E,aAAAA,W,WAAA;AAAA,E,aAKAC,Y,WALA;AAAA,E,aASAC,a,WATA;AAAA;AAAA","file":"ManufacturerProductListPage.module.css.d.ts","sourceRoot":""}

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -70,6 +70,8 @@
     --border: #e3e3e7;
     --border-accent: #cfcfcf;
     --input: #e3e3e7;
+    --overlay: rgb(0 0 0 / 70%);
+    --modal: #f9f9f9;
     --ring: #17171b;
     --transparent: transparent;
     --z-index-overlay: 50;


### PR DESCRIPTION
## 概要
取扱商品一覧画面において，発注確認用のモーダルを追加

## やったこと
- [x] ベースとなるモーダルコンポーネントの実装
- [x] 取扱商品一覧画面のモーダルUIとロジック実装
- [x] 取扱商品一覧画面のUIとロジック修正
  - [x] 発注確認用モーダルを開くための「発注する」ボタンの設置 
  - [x] 発注数について，選択可能上限＝在庫となるよう修正
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] リファクタリング：モーダル部分の別コンポーネントとしての切り出し
- [ ] 詳細なスタイリング（微調整，レスポンス対応）
- [ ] 検討：発注個数を入力する各フォームで，Enterキーを押すと発火する仕様の修正が必要？

## 動作確認
- [x] 適当な商品の発注数を1以上にした状態で「発注する」ボタンを押すと，選択した商品とその個数の一覧が表示される
- [x] 商品をひとつも選んでいない状態で「発注する」ボタンを押すと，「選択されている商品がありません」と表示される

## 伝えるべきこと
### 実装意図


### レビューしてほしい点
- [ ] モーダルの設計やロジックが適切かどうか

### 共有事項

## UI
### 取扱商品一覧画面
before/after
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/9002cfb7-2525-4716-b010-db6000938884)
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/2f089f3f-14ed-42b8-91f1-50b5762bd792)

### 発注確認モーダル
商品がひとつも選択されていない場合
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/421b19b2-bfe6-48ca-bca5-b6743ca6de27)
商品がひとつ以上選択されている場合
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/bb4eef1c-a112-49db-aeda-efb781110066)

## その他
### 参考

