### PR TITLE
[課題1.7] 発注書の一覧を表示する

### DIFF
--- a/packages/client/src/api/shop/index.ts
+++ b/packages/client/src/api/shop/index.ts
@@ -164,3 +164,37 @@ export const postOrder = async (req: postOrderRequest) => {
   const json = (await res.json()) as SuccessResponse<{ data: object }>;
   return json.data;
 };
+
+type FetchOrdersRequest = {
+  shopId: string;
+  token: string;
+};
+
+type FetchOrdersResponse = {
+  id: string;
+  manufacturer: {
+    id: string;
+    name: string;
+    description: string;
+  };
+  approved: boolean;
+  orderAt: string;
+}[];
+
+export const fetchOrders = async (req: FetchOrdersRequest): Promise<FetchOrdersResponse> => {
+  const { shopId, token } = req;
+
+  const res = await fetch(`${APP_API_URL}/shops/${shopId}/orders`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error();
+  }
+  const json = (await res.json()) as SuccessResponse<FetchOrdersResponse>;
+  return json.data;
+};

--- a/packages/client/src/components/domain/shop/HomePage.tsx
+++ b/packages/client/src/components/domain/shop/HomePage.tsx
@@ -52,6 +52,12 @@ export const ShopHomePage = () => {
             href='/shop/manufacturers'
             className={styles.linkCard}
           />
+          <LinkCard
+            title='注文書一覧'
+            description='製造会社への注文書を管理します'
+            href='/shop/orders'
+            className={styles.linkCard}
+          />
         </div>
       </div>
     </>

--- a/packages/client/src/components/domain/shop/Layout.tsx
+++ b/packages/client/src/components/domain/shop/Layout.tsx
@@ -10,6 +10,7 @@ export const ShopLayout = () => {
   const isManufacturerListPage = location.pathname == '/shop/manufacturers';
   const isManufacturerProductListPage =
     location.pathname.includes('/shop/manufacturers') && location.pathname.includes('products');
+  const isOrderListPage = location.pathname == '/shop/orders';
 
   let breadcrumbItems = [{ href: '/shop', title: '販売会社トップ' }];
   if (isLoginPage) {
@@ -24,6 +25,9 @@ export const ShopLayout = () => {
       { href: '/shop/manufacturers', title: '製造会社一覧' },
       { href: location.pathname, title: '取扱商品一覧' },
     ];
+  }
+  if (isOrderListPage) {
+    breadcrumbItems = [...breadcrumbItems, { href: '/shop/orders', title: '注文書一覧' }];
   }
 
   return (

--- a/packages/client/src/components/domain/shop/OrderListPage.tsx
+++ b/packages/client/src/components/domain/shop/OrderListPage.tsx
@@ -1,0 +1,51 @@
+import { Column, Table } from '@/components/case/Table';
+import { useAuthLoaderData } from '@/hooks/useAuthLoaderData';
+import { useEffect, useState } from 'react';
+import * as shopApi from '@/api/shop';
+
+type Response = Awaited<ReturnType<typeof shopApi.fetchOrders>>;
+
+const useOrders = () => {
+  const loaderData = useAuthLoaderData();
+  const shopId = loaderData.id;
+  const token = loaderData.token;
+
+  const [orders, setOrders] = useState<Response>([]);
+
+  useEffect(() => {
+    void shopApi.fetchOrders({ shopId, token }).then((orders) => {
+      setOrders(orders);
+    });
+  }, [shopId, token]);
+
+  return { orders };
+};
+
+export const OrderListPage = () => {
+  const { orders } = useOrders();
+
+  const columns: Column<Response[number]>[] = [
+    {
+      header: '注文書ID',
+      accessor: (item) => item.id,
+    },
+    {
+      header: '注文先',
+      accessor: (item) => item.manufacturer.name,
+    },
+    {
+      header: '承認状況',
+      accessor: (item) => (item.approved ? '承認済' : '未承認'),
+    },
+    {
+      header: '注文日時',
+      accessor: (item) => item.orderAt,
+    },
+  ];
+
+  return (
+    <>
+      <Table columns={columns} data={orders} />
+    </>
+  );
+};

--- a/packages/client/src/pages/shop/orders.tsx
+++ b/packages/client/src/pages/shop/orders.tsx
@@ -1,0 +1,2 @@
+import { OrderListPage } from '@/components/domain/shop/OrderListPage';
+export default OrderListPage;

--- a/packages/client/src/router.tsx
+++ b/packages/client/src/router.tsx
@@ -12,6 +12,7 @@ import ShopLayout from './pages/shop/layout';
 import ShopLoginPage from './pages/shop/login';
 import ShopManufacturerListPage from './pages/shop/manufacturers';
 import ShopManufacturerProductListPage from './pages/shop/manufacturer-products';
+import ShopOrderListPage from './pages/shop/orders';
 
 const router = createBrowserRouter([
   {
@@ -39,6 +40,7 @@ const router = createBrowserRouter([
         element: <ShopManufacturerProductListPage />,
         loader: shopAuthLoader,
       },
+      { path: '/shop/orders', element: <ShopOrderListPage />, loader: shopAuthLoader },
     ],
   },
 ]);


### PR DESCRIPTION
## 概要
注文書一覧画面を実装

## やったこと
- [x] 注文書一覧取得用のAPIの実装
- [x]  注文書一覧画面のUI実装，API繋ぎこみ，パンくずリストの項目追加，ルーティング設定
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] リファクタリング（クエリの切り出しなど．後ほどやる）
- [ ] 例外における表示
  - [ ] データが存在しない場合
  - [ ] 読み込み中の場合
- [ ] UIの改善（ホーム画面以外の画面に対するヘッダの追加など）

## 動作確認
- [x] 自分の，各企業に対する注文一覧が表示される
- [ ] 例外における表示（データがない，取得できないなどの場合）

## 伝えるべきこと
### 実装意図
- 製造会社における発注書一覧画面を参考に実装．設計スタイルを似せることを優先しているため，リファクタが必要そうであれば別途実施する

### レビューしてほしい点
- [ ] ロジックや記法，エラーハンドリング，設計手法が適切かどうか

### 共有事項


## UI
### ホーム画面
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/e8a705b5-96bc-44cd-8e17-ce6c9e00cc72)

### 注文書一覧画面
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/06a89ba0-df08-4940-8860-4f3254379408)


## その他
### 参考

