### PR TITLE
[Refactor] 発注日をわかりやすい形式に変える

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,6 +14,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "date-fns": "^3.4.0",
     "lucide-react": "^0.309.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/client/src/components/domain/manufacturer/OrderListPage.tsx
+++ b/packages/client/src/components/domain/manufacturer/OrderListPage.tsx
@@ -4,7 +4,7 @@ import * as manufacturerApi from '@/api/manufacturer';
 import { Column, Table } from '@/components/case/Table';
 import { useNavigate } from 'react-router-dom';
 import styles from './OrderListPage.module.css';
-import { formatMoney } from '@/libs/utils';
+import { formatMoney, formatDate } from '@/libs/utils';
 
 type Response = Awaited<ReturnType<typeof manufacturerApi.fetchOrders>>;
 
@@ -43,7 +43,7 @@ export const OrderListPage = () => {
     },
     {
       header: '発注日',
-      accessor: (item) => item.orderAt,
+      accessor: (item) => formatDate(item.orderAt),
     },
   ];
 

--- a/packages/client/src/components/domain/manufacturer/OrderPage.tsx
+++ b/packages/client/src/components/domain/manufacturer/OrderPage.tsx
@@ -4,7 +4,7 @@ import * as manufacturerApi from '@/api/manufacturer';
 import { Column, Table } from '@/components/case/Table';
 import { useParams } from 'react-router-dom';
 import styles from './OrderPage.module.css';
-import { formatMoney } from '@/libs/utils';
+import { formatMoney, formatDate } from '@/libs/utils';
 
 type Response = Awaited<ReturnType<typeof manufacturerApi.fetchOrder>>;
 
@@ -67,7 +67,7 @@ export const OrderPage = () => {
     <div className={styles.main}>
       <div>
         <p>発注元: {order.shop.name}</p>
-        <p>発注日: {order.orderAt}</p>
+        <p>発注日: {formatDate(order.orderAt)}</p>
         <p>発注金額: {formatMoney(order.totalPrice)}円</p>
       </div>
       <Table columns={columns} data={items} />

--- a/packages/client/src/libs/utils.ts
+++ b/packages/client/src/libs/utils.ts
@@ -1,7 +1,15 @@
+import { format } from 'date-fns';
+import { ja } from 'date-fns/locale';
+
 export const classNames = (...classes: (string | undefined)[]) => {
   return classes.filter(Boolean).join(' ');
 };
 
 export const formatMoney = (amount: number): string => {
   return amount.toLocaleString('ja-JP', { style: 'currency', currency: 'JPY' });
+};
+
+export const formatDate = (isoString: string): string => {
+  const date = new Date(isoString);
+  return format(date, 'PPpp', { locale: ja });
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
 
   packages/client:
     dependencies:
+      date-fns:
+        specifier: ^3.4.0
+        version: 3.4.0
       lucide-react:
         specifier: ^0.309.0
         version: 0.309.0(react@18.2.0)
@@ -6037,6 +6040,10 @@ packages:
 
   /csstype@3.1.2:
     resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+
+  /date-fns@3.4.0:
+    resolution: {integrity: sha512-Akz4R8J9MXBsOgF1QeWeCsbv6pntT5KCPjU0Q9prBxVmWJYPLhwAIsNg3b0QAdr0ttiozYLD3L/af7Ra0jqYXw==}
+    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}


### PR DESCRIPTION
## 概要
発注日時をわかりやすい形式に変える
- before：`yyyy-mm-ddThh:mm:ss.sssZ`
- after：`yyyy/mm/dd hh:mm:ss`

## やったこと
- [x] フォーマット用関数の実装・適用
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] 

## 動作確認
- [x] 日時が適切にフォーマットされている

## 伝えるべきこと
### 実装意図
- `utils` 系ファイルに切り出した

### レビューしてほしい点
- [ ] 日時が適切にフォーマットされているかどうか

### 共有事項


## UI
| 画面 | before | after | 
| ---- | ---- | ---- |
| 発注書一覧画面 | ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/7444a0cb-240a-4fce-b740-e94c62473da0) | ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/620369a8-f0dc-4885-a80a-cf92fad0f71e) |
| 発注詳細画面 | ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/4dc9ada6-7f47-4d77-a83f-783d816dc2bb) | ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/32144040-0fa8-4596-a132-72a6ec27fcc6) |

## その他
### 参考

