### PR TITLE
[Refactor] 在庫が必要なことを分かりやすく示す

### DIFF
--- a/packages/client/src/components/case/Table.tsx
+++ b/packages/client/src/components/case/Table.tsx
@@ -5,13 +5,24 @@ export type Column<T extends object> = {
   accessor: (item: T) => React.ReactNode;
 };
 
+export type RowStyleCondition<T extends object> = {
+  condition: (item: T) => boolean;
+  className: string;
+};
+
 type TableProps<T extends object> = {
   columns: Column<T>[];
   data: T[];
   onClick?: (item: T) => void;
+  rowStyleCondition?: RowStyleCondition<T>;
 };
 
-export const Table = <T extends object>({ columns, data, onClick }: TableProps<T>) => {
+export const Table = <T extends object>({
+  columns,
+  data,
+  onClick,
+  rowStyleCondition: RowStyleCondition,
+}: TableProps<T>) => {
   return (
     <table className={styles.table}>
       <thead className={styles.thead}>
@@ -24,20 +35,24 @@ export const Table = <T extends object>({ columns, data, onClick }: TableProps<T
         </tr>
       </thead>
       <tbody className={styles.tbody}>
-        {data.map((item, i) => (
-          <tr
-            key={`row_${i}`}
-            className={styles.tr}
-            data-is-clickable={onClick ? 'true' : 'false'}
-            onClick={() => onClick?.(item)}
-          >
-            {columns.map((column) => (
-              <td key={column.header} className={styles.td}>
-                {column.accessor(item)}
-              </td>
-            ))}
-          </tr>
-        ))}
+        {data.map((item, i) => {
+          const conditionStyle =
+            RowStyleCondition && RowStyleCondition.condition(item) ? RowStyleCondition.className : '';
+          return (
+            <tr
+              key={`row_${i}`}
+              className={`${styles.tr} ${conditionStyle}`}
+              data-is-clickable={onClick ? 'true' : 'false'}
+              onClick={() => onClick?.(item)}
+            >
+              {columns.map((column) => (
+                <td key={column.header} className={styles.td}>
+                  {column.accessor(item)}
+                </td>
+              ))}
+            </tr>
+          );
+        })}
       </tbody>
     </table>
   );

--- a/packages/client/src/components/domain/manufacturer/ProductListPage.module.css
+++ b/packages/client/src/components/domain/manufacturer/ProductListPage.module.css
@@ -10,3 +10,7 @@
 .priceCell {
   white-space: nowrap;
 }
+
+.lowStock {
+  background: var(--caution-background);
+}

--- a/packages/client/src/components/domain/manufacturer/ProductListPage.module.css.d.ts
+++ b/packages/client/src/components/domain/manufacturer/ProductListPage.module.css.d.ts
@@ -2,6 +2,7 @@ declare const styles:
   & Readonly<{ "stockCell": string }>
   & Readonly<{ "stockInput": string }>
   & Readonly<{ "priceCell": string }>
+  & Readonly<{ "lowStock": string }>
 ;
 export default styles;
 //# sourceMappingURL=./ProductListPage.module.css.d.ts.map

--- a/packages/client/src/components/domain/manufacturer/ProductListPage.module.css.d.ts.map
+++ b/packages/client/src/components/domain/manufacturer/ProductListPage.module.css.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"sources":["./ProductListPage.module.css"],"names":["stockCell","stockInput","priceCell"],"mappings":"AAAA;AAAA,E,aAAAA,W,WAAA;AAAA,E,aAKAC,Y,WALA;AAAA,E,aASAC,W,WATA;AAAA;AAAA","file":"ProductListPage.module.css.d.ts","sourceRoot":""}
+{"version":3,"sources":["./ProductListPage.module.css"],"names":["stockCell","stockInput","priceCell","lowStock"],"mappings":"AAAA;AAAA,E,aAAAA,W,WAAA;AAAA,E,aAKAC,Y,WALA;AAAA,E,aASAC,W,WATA;AAAA,E,aAaAC,U,WAbA;AAAA;AAAA","file":"ProductListPage.module.css.d.ts","sourceRoot":""}

--- a/packages/client/src/components/domain/manufacturer/ProductListPage.tsx
+++ b/packages/client/src/components/domain/manufacturer/ProductListPage.tsx
@@ -1,5 +1,5 @@
 import { TextInput } from '@/components/base/TextInput';
-import { Column, Table } from '@/components/case/Table';
+import { Column, RowStyleCondition, Table } from '@/components/case/Table';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import styles from './ProductListPage.module.css';
 import { Check } from 'lucide-react';
@@ -32,6 +32,12 @@ const useHandleProducts = () => {
   );
 
   return { products, mutateUpdateStock };
+};
+
+const lowStockThreshold = 5;
+const lowStockContition: RowStyleCondition<Response[number]> = {
+  condition: (item) => item.stock <= lowStockThreshold,
+  className: styles.lowStock,
 };
 
 export const ProductListPage = () => {
@@ -122,7 +128,7 @@ export const ProductListPage = () => {
 
   return (
     <form onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
-      <Table columns={columns} data={products} />
+      <Table columns={columns} data={products} rowStyleCondition={lowStockContition} />
     </form>
   );
 };

--- a/packages/client/src/index.css
+++ b/packages/client/src/index.css
@@ -55,6 +55,7 @@
     --foreground: #08080a;
     --card: #fff;
     --card-foreground: #08080a;
+    --caution-background: #fde4de;
     --popover: #fff;
     --popover-foreground: #08080a;
     --primary: #17171b;


### PR DESCRIPTION
## 概要
製造会社向けの取扱商品一覧画面において，在庫が少ない商品に対するスタイリングを追加

現状，以下のように実装している
- 条件：在庫が5以下のとき
- スタイル：当該行の背景色を薄い赤で塗りつぶす

## やったこと
- [x] インデックススタイルの追加
- [x] テーブルコンポーネントの修正（スタイルと適用条件をpropsに追加） 
- [x] テーブルコンポーネントの適用（条件とスタイルを定義） 
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] さらなるスタイリング（セルを塗りつぶす以外）
- [ ] その他の「分かりやすく示す」手法（アラートモーダルを出す，アイコンを表示する，など）
- [ ] しきい値の柔軟な変更 

## 動作確認
- [x] 在庫数がしきい値より多いとき，スタイルが適用されない
- [x] 在庫数がしきい値以下のとき，スタイルが適用される

## 伝えるべきこと
### 実装意図
- より少ない実装コストでより分かりやすく示すため，簡易的に表を塗りつぶす方針を選んだ

### レビューしてほしい点
- [ ] 設計や記法が適切かどうか（拡張性など）

### 共有事項


## UI
before/after
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/6cd0c199-ce8e-41f9-8630-8e51b8f36f2f)
![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/25c56534-2adf-485d-8824-93feee32ee32)


## その他
### 参考

