### PR TITLE
[Refactor] 取り扱い商品一覧に発注数を表示する

### DIFF
--- a/packages/client/src/api/manufacturer/index.ts
+++ b/packages/client/src/api/manufacturer/index.ts
@@ -76,6 +76,7 @@ type FetchHandlingProductsResponse = {
   categories: { id: string; name: string }[];
   price: number;
   stock: number;
+  orderQuantity: number;
 }[];
 
 export const fetchHandlingProducts = async (

--- a/packages/client/src/components/domain/manufacturer/ProductListPage.tsx
+++ b/packages/client/src/components/domain/manufacturer/ProductListPage.tsx
@@ -142,6 +142,11 @@ export const ProductListPage = () => {
       width: '5%',
     },
     {
+      header: '発注数',
+      accessor: (item) => item.orderQuantity,
+      width: '5%',
+    },
+    {
       header: '在庫',
       accessor: (item) => (
         <div className={styles.stockCell}>


### PR DESCRIPTION
## 概要
製造会社の取扱商品一覧画面において，発注数を表示する列を追加

## やったこと
- [x] backendクエリの変更
- [x] frontendAPIの変更
- [x] 取扱商品一覧画面におけるカラムの追加  
- [x] 動作確認とセルフレビュー 

## やらないこと
- [ ] 

## 動作確認
- [ ]

## 伝えるべきこと
### 実装意図
- 最低限の変更で済むよう心掛けた
- 発注数を計算するロジックを切り出している．切り出すこと自体，また切り出した処理が適切かどうか確認してほしい

### レビューしてほしい点
- [ ] backendクエリの処理が適切かどうか

### 共有事項


## UI
| before | after |
| ---- | ---- |
| ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/3e9972d7-84a0-43fe-b498-7e47d42b53fe) | ![image](https://github.com/pkmiya/gx-frontend-challenges/assets/66787330/ce4a68de-77e7-498e-82cf-be169a2a5217) |

## その他
### 参考

